### PR TITLE
Remove alpha channel in iconizer

### DIFF
--- a/iconizer.sh
+++ b/iconizer.sh
@@ -45,7 +45,7 @@ do
       echo "File $newFileName already created... Continue"
     else
       echo -n "Creating $newFileName and update $CONTENTS_FILE..."
-      convert -density 400 "$1" -scale "$sizePX" "$2/$newFileName"
+      convert -alpha off -density 400 "$1" -scale "$sizePX" "$2/$newFileName"
       echo "✅"
     fi
 


### PR DESCRIPTION
Strips the alpha channel when creating all icon from the PDF to prevent
the following error when uploading to itunes connect:

"Invalid App Store Icon. The App Store Icon in the asset catalog in
'****.app' can't be transparent nor contain an alpha channel."