### PR TITLE
Fix deprecated File.exists

### DIFF
--- a/jwt.rb
+++ b/jwt.rb
@@ -11,7 +11,7 @@ key_file_or_string = ARGV[0]
 key_id = "#{ARGV[1]}"
 issuer_id = "#{ARGV[2]}"
 
-if File.exists?("#{key_file_or_string}")
+if File.exist?("#{key_file_or_string}")
   private_key = OpenSSL::PKey.read(File.read("#{key_file_or_string}"))
 else
   private_key = OpenSSL::PKey.read("#{key_file_or_string}")


### PR DESCRIPTION
`File.exists` is deprecated since 2.7, from the warning below `File.exist` should be used instead.
> rb_warning("%sexists? is a deprecated name, use %sexist? instead", s, s);

Reference: https://docs.ruby-lang.org/en/2.7.0/File.html#method-c-exists-3F